### PR TITLE
Update IAM permissions for EC2 Image Builder

### DIFF
--- a/cf-pipeline.yaml
+++ b/cf-pipeline.yaml
@@ -706,7 +706,7 @@ Resources:
             Effect: Allow
             Resource: 
               - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/*/*"
-              - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/*/*/*"
+              - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:*:image/amazon-linux-2-*/*/*"
               - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/*/*"
               - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/*/*"
               - !Sub "arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/*/*/*"


### PR DESCRIPTION
Allow imagebuilder:GetImage to obtain images from other accounts, required to get the standard Amazon Linux 2 images. Restrict to Amazon Linux only for this example to avoid too wide open permissions.

*Issue #, if available:*
#4

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
